### PR TITLE
2.0.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+2.0.2 (2019-06-21)
+------------------
+
+* Zed\_utf8: fix an ofs-stepping bug in function `unsafe_extract_prev`
+
 2.0.1 (2019-06-04)
 ------------------
 
@@ -12,8 +17,7 @@
 ### Additions
 
 * module Zed\_char
-* module Zed\_string
-* Zed\_cursor
+* module Zed\_string * Zed\_cursor
   * `column_display: Zed_cursor.t -> int React.signal`
   * `get_column: Zed_cursor.t -> int`
   * `coordinates_display: Zed_cursor.t -> (int * int) React.signal`

--- a/src/zed_utf8.ml
+++ b/src/zed_utf8.ml
@@ -228,7 +228,7 @@ let unsafe_extract_prev str ofs =
                           let ch4 = String.unsafe_get str (ofs - 4) in
                           match ch4 with
                             | '\xf0' .. '\xf7' ->
-                                (UChar.of_int (((Char.code ch4 land 0x07) lsl 18) lor ((Char.code ch3 land 0x3f) lsl 12) lor ((Char.code ch2 land 0x3f) lsl 6) lor (Char.code ch1 land 0x3f)), ofs + 4)
+                                (UChar.of_int (((Char.code ch4 land 0x07) lsl 18) lor ((Char.code ch3 land 0x3f) lsl 12) lor ((Char.code ch2 land 0x3f) lsl 6) lor (Char.code ch1 land 0x3f)), ofs - 4)
                             | _ ->
                                 fail str (ofs - 4) "invalid start of UTF-8 sequence"
                         else


### PR DESCRIPTION
* Zed\_utf8: fix an ofs-stepping bug in function `unsafe_extract_prev`