### PR TITLE
release 2.0.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+2.0.2 (2019-06-21)
+------------------
+
+* Zed\_utf8: fix an ofs-stepping bug in function `unsafe_extract_prev`
+
 2.0.1 (2019-06-04)
 ------------------
 


### PR DESCRIPTION
* Zed\_utf8: fix an ofs-stepping bug in function `unsafe_extract_prev`