### PR TITLE
release 2.0.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+2.0.3 (2019-08-09)
+------------------
+
+* Zed\_string
+  * `exception Invalid of string * string` raised when an invalid Zed\_char sequence is encounted
+  * `next_ofs : t -> int -> int` returns the offset of the next zchar in `t`
+  * `prev_ofs : t -> int -> int` returns the offset of the prev zchar in `t`
+
 2.0.2 (2019-06-21)
 ------------------
 

--- a/zed.opam
+++ b/zed.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "opam-devel@lists.ocaml.org"
 authors: ["Jérémie Dimino"]
 homepage: "https://github.com/ocaml-community/zed"
@@ -6,15 +6,23 @@ bug-reports: "https://github.com/ocaml-community/zed/issues"
 dev-repo: "git://github.com/ocaml-community/zed.git"
 license: "BSD3"
 depends: [
-  "dune" {build & >= "1.0.0"}
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.1.0"}
   "base-bytes"
   "camomile" {>= "1.0.1"}
   "react"
   "charInfo_width" {>= "1.1.0" & < "2.0~"}
 ]
 build: [
-  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-build-test: [["dune" "runtest" "-p" name "-j" jobs]]
-available: [ocaml-version >= "4.02.3"]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""


### PR DESCRIPTION
* Zed\_string
  * `exception Invalid of string * string` raised when an invalid Zed\_char sequence is encounted
  * `next_ofs : t -> int -> int` returns the offset of the next zchar in `t`
  * `prev_ofs : t -> int -> int` returns the offset of the prev zchar in `t`