### PR TITLE
wanted_column now works with wide graphemes

### DIFF
--- a/src/zed_edit.ml
+++ b/src/zed_edit.ml
@@ -232,14 +232,18 @@ let next_line_n ctx n =
   if index + n > Zed_lines.count ctx.edit.lines then
     goto ctx ~set_wanted_column:false (Zed_rope.length ctx.edit.text)
   else begin
-    let start = Zed_lines.line_start ctx.edit.lines (index + n) in
     let stop =
       if index + n = Zed_lines.count ctx.edit.lines then
         Zed_rope.length ctx.edit.text
       else
         Zed_lines.line_start ctx.edit.lines (index + n + 1) - 1
     in
-    goto ctx ~set_wanted_column:false (start + min (Zed_cursor.get_wanted_column ctx.cursor) (stop - start))
+    let wanted_idx= Zed_lines.get_idx_by_width
+        ctx.edit.lines
+        (index + n)
+        (Zed_cursor.get_wanted_column ctx.cursor)
+    in
+    goto ctx ~set_wanted_column:false (min wanted_idx stop)
   end
 
 let prev_line_n ctx n =
@@ -247,9 +251,13 @@ let prev_line_n ctx n =
   if index - n < 0 then begin
     goto ctx ~set_wanted_column:false 0
   end else begin
-    let start = Zed_lines.line_start ctx.edit.lines (index - n) in
     let stop = Zed_lines.line_start ctx.edit.lines (index - (n - 1)) - 1 in
-    goto ctx ~set_wanted_column:false (start + min (Zed_cursor.get_wanted_column ctx.cursor) (stop - start))
+    let wanted_idx= Zed_lines.get_idx_by_width
+        ctx.edit.lines
+        (index - n)
+        (Zed_cursor.get_wanted_column ctx.cursor)
+    in
+    goto ctx ~set_wanted_column:false (min wanted_idx stop)
   end
 
 let move_line ctx delta =
@@ -418,14 +426,18 @@ let next_line ctx =
   if index = Zed_lines.count ctx.edit.lines then
     goto ctx ~set_wanted_column:false (Zed_rope.length ctx.edit.text)
   else begin
-    let start = Zed_lines.line_start ctx.edit.lines (index + 1) in
     let stop =
       if index + 1 = Zed_lines.count ctx.edit.lines then
         Zed_rope.length ctx.edit.text
       else
         Zed_lines.line_start ctx.edit.lines (index + 2) - 1
     in
-    goto ctx ~set_wanted_column:false (start + min (Zed_cursor.get_wanted_column ctx.cursor) (stop - start))
+    let wanted_idx= Zed_lines.get_idx_by_width
+        ctx.edit.lines
+        (index + 1)
+        (Zed_cursor.get_wanted_column ctx.cursor)
+    in
+    goto ctx ~set_wanted_column:false (min wanted_idx stop)
   end
 
 let prev_line ctx =
@@ -433,9 +445,13 @@ let prev_line ctx =
   if index = 0 then begin
     goto ctx ~set_wanted_column:false 0
   end else begin
-    let start = Zed_lines.line_start ctx.edit.lines (index - 1) in
     let stop = Zed_lines.line_start ctx.edit.lines index - 1 in
-    goto ctx ~set_wanted_column:false (start + min (Zed_cursor.get_wanted_column ctx.cursor) (stop - start))
+    let wanted_idx= Zed_lines.get_idx_by_width
+        ctx.edit.lines
+        (index - 1)
+        (Zed_cursor.get_wanted_column ctx.cursor)
+    in
+    goto ctx ~set_wanted_column:false (min wanted_idx stop)
   end
 
 let goto_bol ctx =

--- a/src/zed_lines.ml
+++ b/src/zed_lines.ml
@@ -325,3 +325,21 @@ let of_rope rope =
   in
   loop0 (Zed_rope.Zip.make_f rope 0) empty
 
+(* +-----------------------------------------------------------------+
+   | Index and width                                                 |
+   +-----------------------------------------------------------------+ *)
+
+let get_idx_by_width set row column=
+  let start= line_start set row in
+  let stop= line_stop set row in
+  let rec get idx acc_width=
+    if acc_width >= column || idx >= stop then
+      idx
+    else
+      let curr_width= force_width set idx 1 in
+      if acc_width + curr_width > column
+      then idx (* the width of the current char covers the column *)
+      else get (idx+1) (acc_width + curr_width)
+  in
+  get start 0
+

--- a/src/zed_lines.mli
+++ b/src/zed_lines.mli
@@ -75,6 +75,6 @@ val replace : t -> int -> int -> t -> t
       [offset] and length [length] by [repl] in [set]. *)
 
 val get_idx_by_width : t -> int -> int -> int
-  (** [get_idx_by_width set column_width] return the offset of the char at
-      given column_width. *)
+  (** [get_idx_by_width set row column_width] return the offset of the char
+      at \[row, column_width\]. *)
 

--- a/src/zed_lines.mli
+++ b/src/zed_lines.mli
@@ -74,3 +74,7 @@ val replace : t -> int -> int -> t -> t
   (** [replace set offset length repl] replaces the subset at offset
       [offset] and length [length] by [repl] in [set]. *)
 
+val get_idx_by_width : t -> int -> int -> int
+  (** [get_idx_by_width set column_width] return the offset of the char at
+      given column_width. *)
+


### PR DESCRIPTION
The wanted_column now works with wide graphemes.

Instead of recording the offset, the wanted_column value records the current column_display which is based on the width of the graphemes.

Every time a user goto prev_n or next_n lines, goto bol, eol etc it now calculates the offset at the given column_width and set the result offset as the new position.

<details><summary>Click to expand the GIFs</summary>
before this patch

![before](https://user-images.githubusercontent.com/357626/67878686-b309fe00-fb76-11e9-81ae-c91808c1d1e6.gif)
after this patch

![after](https://user-images.githubusercontent.com/357626/67879753-763f0680-fb78-11e9-9fdb-ce38a6e2ea8c.gif)

</details>