### PR TITLE
Fix scoping error due to the introduction of `Result.compare` in result.1.5.

### DIFF
--- a/src/zed_string.ml
+++ b/src/zed_string.ml
@@ -7,6 +7,10 @@
  * This file is a part of Zed, an editor engine.
  *)
 
+(* This aliasing needs to come before 'open Result' which now offers a
+   'compare' function. We don't use 'Pervasives.compare' or 'Stdlib.compare'
+   because neither seems to work with every version of OCaml. *)
+let pervasives_compare= compare
 
 open CamomileLibraryDefault.Camomile
 open Result
@@ -15,8 +19,6 @@ exception Invalid of string * string
 exception Out_of_bounds
   (** Exception raised when trying to access a character which is
       outside the bounds of a string. *)
-
-let pervasives_compare= compare
 
 let fail str pos msg = raise (Invalid(Printf.sprintf "at position %d: %s" pos msg, str))
 


### PR DESCRIPTION
Hi, we ran into this error:

```
# Error: The implementation src/zed_string.ml
# [...]
#          val compare_index :
#            t ->
#            ('a, 'b) result ->
#            ('a, 'b) result ->
#            ok:('a -> 'a -> int) -> error:('b -> 'b -> int) -> int
#        is not included in
#          val compare_index : t -> index -> index -> int
#        File "src/zed_string.mli", line 184, characters 0-46:
#          Expected declaration
#        File "src/zed_string.ml", line 454, characters 6-19:
#          Actual declaration
```

The strange signature for the `compare` function is from the `Result` module which provides its own `compare` since version 1.5.

Hopefully this PR fixes the build for all OCaml versions supported by zed. See also the opam-repository PR https://github.com/ocaml/opam-repository/pull/15909
