### PR TITLE
Actions

### DIFF
--- a/src/zed_edit.ml
+++ b/src/zed_edit.ml
@@ -749,6 +749,7 @@ type action =
   | Prev_char
   | Next_line
   | Prev_line
+  | Goto of int
   | Goto_bol
   | Goto_eol
   | Goto_bot
@@ -790,6 +791,7 @@ let get_action = function
   | Prev_char -> prev_char
   | Next_line -> next_line
   | Prev_line -> prev_line
+  | Goto n -> fun ctx-> goto ctx n
   | Goto_bol -> goto_bol
   | Goto_eol -> goto_eol
   | Goto_bot -> goto_bot
@@ -828,6 +830,7 @@ let doc_of_action = function
   | Prev_char -> "move the cursor to the previous character."
   | Next_line -> "move the cursor to the next line."
   | Prev_line -> "move the cursor to the previous line."
+  | Goto _-> "move the cursor to the position"
   | Goto_bol -> "move the cursor to the beginning of the current line."
   | Goto_eol -> "move the cursor to the end of the current line."
   | Goto_bot -> "move the cursor to the beginning of the text."

--- a/src/zed_edit.ml
+++ b/src/zed_edit.ml
@@ -595,6 +595,11 @@ let copy ctx =
     ctx.edit.set_selection false
   end
 
+let copy_sequence ctx start len=
+  if start >= 0 && len < Zed_rope.length ctx.edit.text then
+    ctx.edit.clipboard.clipboard_set
+      (Zed_rope.sub ctx.edit.text start len)
+
 let kill ctx =
   if S.value ctx.edit.selection then begin
     let a = Zed_cursor.get_position ctx.cursor and b = Zed_cursor.get_position ctx.edit.mark in

--- a/src/zed_edit.mli
+++ b/src/zed_edit.mli
@@ -379,6 +379,10 @@ type action =
   | Goto_eol
   | Goto_bot
   | Goto_eot
+  | Delete_next_chars of int
+  | Delete_prev_chars of int
+  | Kill_next_chars of int
+  | Kill_prev_chars of int
   | Delete_next_char
   | Delete_prev_char
   | Delete_next_line

--- a/src/zed_edit.mli
+++ b/src/zed_edit.mli
@@ -375,6 +375,7 @@ type action =
   | Prev_char
   | Next_line
   | Prev_line
+  | Goto of int
   | Goto_bol
   | Goto_eol
   | Goto_bot

--- a/src/zed_edit.mli
+++ b/src/zed_edit.mli
@@ -375,6 +375,7 @@ type action =
   | Prev_char
   | Next_line
   | Prev_line
+  | Join_line
   | Goto of int
   | Goto_bol
   | Goto_eol

--- a/src/zed_edit.mli
+++ b/src/zed_edit.mli
@@ -321,6 +321,10 @@ val copy : 'a context -> unit
   (** [copy ctx] copies the current selectionned region to the
       clipboard. *)
 
+val copy_sequence: 'a context -> int -> int -> unit
+  (** [copy_sequence ctx start len] copies [len] characters start
+      from [start] to the clipboard. *)
+
 val kill : 'a context -> unit
   (** [kill ctx] copies the current selectionned region to the
       clipboard and remove it. *)


### PR DESCRIPTION
This PR adds some new actions for the convenience of repetitive operation.
This is also a part of the vi-mode utop lambda-term progress.

* `Zed_edit`:
  * new actions:
    * `Join_line`
    * `Goto of int`
    * `Delete_next_chars of int`
    * `Delete_prev_chars of int`
    * `Kill_next_chars of int`
    * `Kill_prev_chars of int`
  * function `copy_sequence`