### PR TITLE
Remove `bytes` and `base-bytes`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,6 @@ cursor management facilities.")
  (depends
   (ocaml
    (>= 4.02.3))
-  base-bytes
   react
   result
   uutf

--- a/src/dune
+++ b/src/dune
@@ -3,4 +3,4 @@
   (public_name zed)
   (wrapped false)
   (flags (:standard -safe-string))
-  (libraries bytes react result uutf uucp uuseg))
+  (libraries react result uutf uucp uuseg))

--- a/zed.opam
+++ b/zed.opam
@@ -17,7 +17,6 @@ bug-reports: "https://github.com/ocaml-community/zed/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.02.3"}
-  "base-bytes"
   "react"
   "result"
   "uutf"


### PR DESCRIPTION
This removes the bytes library which hasn't been necessary since OCaml 4.02, and thus reduces the dependency cone.