### PR TITLE
next_error: check if decoded value fits in Uchar

### DIFF
--- a/src/zed_utf8.ml
+++ b/src/zed_utf8.ml
@@ -74,8 +74,12 @@ let next_error s i =
                 (i, ulen, "malformed UTF8 sequence")
               else if byte3 land 0xc0 != 0x80 then
                 (i, ulen, "malformed UTF8 sequence")
-              else if ((Char.code ch land 0x07) lsl 18) lor ((byte1 land 0x3f) lsl 12) lor ((byte2 land 0x3f) lsl 6) lor (byte3 land 0x3f) < 0x10000 then
+              else
+                let value = ((Char.code ch land 0x07) lsl 18) lor ((byte1 land 0x3f) lsl 12) lor ((byte2 land 0x3f) lsl 6) lor (byte3 land 0x3f) in
+                if value < 0x10000 then
                 (i, ulen, "overlong UTF8 sequence")
+              else if value > Uchar.to_int Uchar.max then
+                (i, ulen, "scalar value too large in UTF8 sequence")
               else
                 main (i + 4) (ulen + 1)
             end

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test_zed)
+ (libraries zed))

--- a/test/test_zed.expected
+++ b/test/test_zed.expected
@@ -1,1 +1,1 @@
-next_error "\247\165\165\165" = (0, _, "scalar value too large in UTF8 sequence")
+next_error (scalar value too large) = (0, _, "scalar value too large in UTF8 sequence")

--- a/test/test_zed.expected
+++ b/test/test_zed.expected
@@ -1,0 +1,1 @@
+next_error "\247\165\165\165" = (0, _, "scalar value too large in UTF8 sequence")

--- a/test/test_zed.ml
+++ b/test/test_zed.ml
@@ -1,0 +1,4 @@
+let () =
+  let s = "\247\165\165\165" in
+  let (ofs, _, message) = Zed_utf8.next_error s 0 in
+  Printf.printf "next_error %S = (%d, _, %S)\n" s ofs message

--- a/test/test_zed.ml
+++ b/test/test_zed.ml
@@ -1,4 +1,4 @@
 let () =
   let s = "\247\165\165\165" in
   let (ofs, _, message) = Zed_utf8.next_error s 0 in
-  Printf.printf "next_error %S = (%d, _, %S)\n" s ofs message
+  Printf.printf "next_error (scalar value too large) = (%d, _, %S)\n" ofs message


### PR DESCRIPTION
The value can be larger than `Uchar.max` - in that case zed would previously return no error but functions such as `explode` would later raise an exception.

See ocaml-community/utop#401
