### PR TITLE
`of_utf8`: add `Uchar.is_valid` to check the input

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,7 @@
 (library
-  (name zed)
-  (public_name zed)
-  (wrapped false)
-  (flags (:standard -safe-string))
-  (libraries react result uchar uutf uucp uuseg))
+ (name zed)
+ (public_name zed)
+ (wrapped false)
+ (flags
+  (:standard -safe-string))
+ (libraries react result uchar uutf uucp uuseg))

--- a/src/zed_utf8.ml
+++ b/src/zed_utf8.ml
@@ -178,13 +178,26 @@ let unsafe_extract str ofs =
     | '\xe0' .. '\xef' ->
         if ofs + 3 > String.length str then
           fail str ofs "unterminated UTF-8 sequence"
-        else
-          Uchar.of_int (((Char.code ch land 0x0f) lsl 12) lor ((byte str (ofs + 1) land 0x3f) lsl 6) lor (byte str (ofs + 2) land 0x3f))
+        else (
+          let n = ((Char.code ch land 0x0f) lsl 12) lor
+                  ((byte str (ofs + 1) land 0x3f) lsl 6) lor
+                    (byte str (ofs + 2) land 0x3f) in
+          if not (Uchar.is_valid n) then
+            fail str ofs "not a Unicode scalar value"
+          else
+            Uchar.of_int n)
     | '\xf0' .. '\xf7' ->
         if ofs + 4 > String.length str then
           fail str ofs "unterminated UTF-8 sequence"
-        else
-          Uchar.of_int (((Char.code ch land 0x07) lsl 18) lor ((byte str (ofs + 1) land 0x3f) lsl 12) lor ((byte str (ofs + 2) land 0x3f) lsl 6) lor (byte str (ofs + 3) land 0x3f))
+        else (
+          let n = (((Char.code ch land 0x07) lsl 18) lor
+                    ((byte str (ofs + 1) land 0x3f) lsl 12) lor
+                    ((byte str (ofs + 2) land 0x3f) lsl  6) lor
+                    (byte str (ofs + 3) land 0x3f)) in
+          if not (Uchar.is_valid n) then
+            fail str ofs "not a Unicode scalar value"
+          else
+            Uchar.of_int n)
     | _ ->
         fail str ofs "invalid start of UTF-8 sequence"
 

--- a/test/test_zed.expected
+++ b/test/test_zed.expected
@@ -1,2 +1,5 @@
 next_error (scalar value too large) = (0, _, "scalar value too large in UTF8 sequence")
 Zed_utf8.Out_of_bounds.
+Zed_utf8.Invalid raised.
+Zed_utf8.Invalid raised.
+Zed_utf8.Invalid raised.

--- a/test/test_zed.ml
+++ b/test/test_zed.ml
@@ -11,3 +11,18 @@ let () =
     | exception Zed_utf8.Out_of_bounds -> "Zed_utf8.Out_of_bounds.\n"
     | exception Zed_utf8.Invalid _ -> "Zed_utf8.Invalid.\n")
 
+
+let of_utf8_exception_handling_test str =
+  match Zed_string.of_utf8 str with
+  | _ -> Printf.printf "OK\n"
+  | exception Zed_string.Invalid _ -> Printf.printf "Zed_string.Invalid raised.\n"
+  | exception Zed_utf8.Invalid _ -> Printf.printf "Zed_utf8.Invalid raised.\n"
+  | exception _ -> Printf.printf "ERROR, another exception has been raised.\n"
+
+let () =
+  let uchar_max_str = "\xf4\x90\x80\x80" in (* U+110000 *)
+  let d800_str = "\xed\xa0\x80" in (* U+D800 *)
+  let dfff_str = "\xed\xbf\xbf" in (* U+DFFF *)
+  of_utf8_exception_handling_test uchar_max_str;
+  of_utf8_exception_handling_test d800_str;
+  of_utf8_exception_handling_test dfff_str

--- a/test/test_zed.ml
+++ b/test/test_zed.ml
@@ -11,7 +11,6 @@ let () =
     | exception Zed_utf8.Out_of_bounds -> "Zed_utf8.Out_of_bounds.\n"
     | exception Zed_utf8.Invalid _ -> "Zed_utf8.Invalid.\n")
 
-
 let of_utf8_exception_handling_test str =
   match Zed_string.of_utf8 str with
   | _ -> Printf.printf "OK\n"


### PR DESCRIPTION
According to the documentation (https://ocaml.org/p/zed/2.0.6/doc/Zed_string/index.html#val-of_utf8), `Zed_string.of_utf8` should not raise `Stdlib.Invalid_argument` if the input is not valid. `Uchar.is_valid` returns `false` if the value is bigger than `Uchar.max` (`U+10FFFF`) or belongs to the invalid Unicode range (from `U+D800` to `U+DFFF`). In this case, `Zed_string.of_utf8` raises `Zed_utf8.Invalid (input, "not a Unicode scalar value")`.