### PR TITLE
`Zed_utf8.next_error`: raise `Zed_utf8.Out_of_bounds` in case of invalid offset.

### DIFF
--- a/src/zed_utf8.mli
+++ b/src/zed_utf8.mli
@@ -46,7 +46,10 @@ val next_error : t -> int -> int * int * string
       [ofs] (inclusive) in [str], [count] is the number of unicode
       character between [ofs] and [ofs'] (exclusive) and [msg] is an
       error message. If there is no error until the end of string then
-      [ofs] is [String.length str] and [msg] is the empty string. *)
+      [ofs] is [String.length str] and [msg] is the empty string.
+
+    @raise [Zed_utf8.Invalid] if [str] is not a correct UTF8 sequence.
+    @raise [Zed_utf8.Out_of_bounds] if [ofs] not an index of [str]. *)
 
 (** {5 Construction} *)
 

--- a/test/test_zed.expected
+++ b/test/test_zed.expected
@@ -1,1 +1,2 @@
 next_error (scalar value too large) = (0, _, "scalar value too large in UTF8 sequence")
+Zed_utf8.Out_of_bounds.

--- a/test/test_zed.ml
+++ b/test/test_zed.ml
@@ -2,3 +2,12 @@ let () =
   let s = "\247\165\165\165" in
   let (ofs, _, message) = Zed_utf8.next_error s 0 in
   Printf.printf "next_error (scalar value too large) = (%d, _, %S)\n" ofs message
+
+let () =
+  let str = "cat" in
+  let ofs = (String.length str)  in
+  Printf.printf (match Zed_utf8.next_error str ofs with
+    | _ -> "OK.\n"
+    | exception Zed_utf8.Out_of_bounds -> "Zed_utf8.Out_of_bounds.\n"
+    | exception Zed_utf8.Invalid _ -> "Zed_utf8.Invalid.\n")
+


### PR DESCRIPTION
`Zed_utf8.next_error string offset` should fail with `Zed_utf8.Out_of_bounds`, when `offset` does not belong to a valid range (from 0 to `string`'s length).