### PR TITLE
fix: replace camomile with uutf/uucp in dune-project description

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -18,7 +18,7 @@
  (synopsis "Abstract engine for text edition in OCaml")
  (description
   "Zed is an abstract engine for text edition. It can be used to write text
-editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+editors, edition widgets, readlines, ... Zed uses uutf and uucp to fully support the
 Unicode specification, and implements an UTF-8 encoded string type with
 validation, and a rope datastructure to achieve efficient operations on large
 Unicode buffers. Zed also features a regular expression search on ropes. To


### PR DESCRIPTION
This typo came to my attention when I came across the package definition of `zed` in Guix. My understanding is that `camomile` has been replaced with `uu*` packages.